### PR TITLE
Deleted CentOS7 AMI in terraform config and fixed a minor ansible typo

### DIFF
--- a/ansible/roles/aws-jumphost/tasks/main.yaml
+++ b/ansible/roles/aws-jumphost/tasks/main.yaml
@@ -76,4 +76,4 @@
   shell: |
     /usr/bin/ansible-playbook /home/ubuntu/ansible/main.yaml -i /home/ubuntu/ansible/aws.hosts --limit '!aws_jh_pub'
     scp -r /home/ubuntu/terraform/ jumphost02{{ aws_data.dnsSuffix }}.{{ aws_data.dnsZone }}:/home/ubuntu/
-    scp -r /home/ubuntu/ansible/ jumphost0{{ aws_data.dnsSuffix }}.{{ aws_data.dnsZone }}:/home/ubuntu/
+    scp -r /home/ubuntu/ansible/ jumphost02{{ aws_data.dnsSuffix }}.{{ aws_data.dnsZone }}:/home/ubuntu/

--- a/terraform/config-files/se32-aws.yaml
+++ b/terraform/config-files/se32-aws.yaml
@@ -53,10 +53,6 @@ vpcs:
         public: false
     dbGroup: false
 amis:
-  centos7:
-    ami: CentOS Linux 7 x86_64 - 2211
-    owner: '125523088429'
-    user: centos
   alma9:
     ami: AlmaLinux OS 9.4.20240509 x86_64
     owner: '764336703387'


### PR DESCRIPTION
Deleted CentOS7 AMI in terraform config and fixed a minor typo in one of the ansible config files